### PR TITLE
fix: Keptn compatibility for argo and prometheus

### DIFF
--- a/argo/0.9.0/artifacthub-pkg.yml
+++ b/argo/0.9.0/artifacthub-pkg.yml
@@ -20,4 +20,4 @@ recommendations:
 annotations:
   keptn/kind: deployment
   keptn/org: contrib
-  keptn/version: 0.8.4-0.8.7
+  keptn/version: 0.8.4-0.10.0

--- a/prometheus/0.7.2/artifacthub-pkg.yml
+++ b/prometheus/0.7.2/artifacthub-pkg.yml
@@ -59,4 +59,4 @@ recommendations:
 annotations:
   keptn/kind: observability
   keptn/org: contrib
-  keptn/version: 0.9.0
+  keptn/version: 0.9.0-0.11.3


### PR DESCRIPTION
Adapting latest release of argo-service and prometheus-service with Keptn compatibility version