### PR TITLE
Fixed wrong version ordering in check_for_new_releases.py

### DIFF
--- a/check_for_new_releases.py
+++ b/check_for_new_releases.py
@@ -7,7 +7,7 @@ from utils import replace_relative_paths, DATETIME_FORMAT
 def get_subdirectories(d: str) -> list:
     """Gets all the subdirectors of directory d"""
     # https://stackoverflow.com/a/973492
-    return [o for o in os.listdir(d)
+    return [o for o in sorted(os.listdir(d))
             if os.path.isdir(os.path.join(d, o))]
 
 


### PR DESCRIPTION
Fixes #65. Old folder ordering:

```
['0.3.1']
['0.9.1', '0.8.4']
['0.3.2']
['0.1.5']
['0.2.0']
['0.2.1']
['0.7.2', '0.7.1', '0.6.2', '0.6.1']
['0.3.0']
['0.1.0']
['5.0', '5.1.2', '5.1']
['0.9.0', '0.8.4']
['0.1.0']
['0.9.0', '0.8.0']
['0.8.5']
['0.0.1']
['0.1.3', '0.1.4', '0.1.5']
['0.16.0', '0.18.1', '0.20.0', '0.19.0', '0.18.0', '0.17.0']
['0.1.0']
['0.3.1']
['0.1.0']
```

New ordering:

```
['0.8.4', '0.9.0']
['0.3.1']
['0.16.0', '0.17.0', '0.18.0', '0.18.1', '0.19.0', '0.20.0']
['0.1.0']
['0.1.0']
['5.0', '5.1', '5.1.2']
['0.8.5']
['0.1.0']
['0.1.3', '0.1.4', '0.1.5']
['0.2.1']
['0.1.5']
['0.8.4', '0.9.1']
['0.8.0', '0.9.0']
['0.3.1']
['0.0.1']
['0.6.1', '0.6.2', '0.7.1', '0.7.2']
['0.3.0']
['0.1.0']
['0.2.0']
['0.3.2']
```