### PR TITLE
feat: Changed release check Github action to only check last day

### DIFF
--- a/.github/workflows/release_check.yml
+++ b/.github/workflows/release_check.yml
@@ -27,7 +27,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          python check_for_new_releases.py
+          python check_for_new_releases.py -t 1
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
@@ -35,6 +35,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "New releases"
           signoff: true
+          branch-suffix: timestamp
           delete-branch: true
           base: main
           title: "New releases"

--- a/check_for_new_releases.py
+++ b/check_for_new_releases.py
@@ -36,7 +36,7 @@ if __name__ == '__main__':
     if github_token:
         g = Github(github_token)
     else:
-        g = Github('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')
+        g = Github('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')
 
     for d in directories:
         try:
@@ -58,10 +58,10 @@ if __name__ == '__main__':
 
                 try:
                     releases_paginated_list = repo.get_releases()
-                    releases = []
-                    for release in releases_paginated_list:
-                        if release.prerelease == False and (args.timeframe == -1 or release.published_at > datetime.datetime.now() - datetime.timedelta(days=args.timeframe)):
-                            releases.append(release)
+                    min_time = datetime.datetime.min if args.timeframe == - \
+                        1 else datetime.datetime.now() - datetime.timedelta(days=args.timeframe)
+                    releases = [release for release in releases_paginated_list if release.prerelease ==
+                                False and release.published_at > min_time]
                 except:
                     print(f'{d} has no release. Skipping!')
                     continue


### PR DESCRIPTION
`check_for_new_releases.py` file now has an `timeframe` CLI argument that allows the user to specify how many days in the past the script should check. The script now also supports multiple releases in the set timeframe (before only the latest release was checked). Also the release check now uses a different branch name for each release.