### PR TITLE
Fix: compatibility of prometheus and job-executor

### DIFF
--- a/job-executor/0.1.6/artifacthub-pkg.yml
+++ b/job-executor/0.1.6/artifacthub-pkg.yml
@@ -5,7 +5,7 @@ createdAt: '2022-01-25T08:27:50Z'
 description: Keptn service to run any container as a Kubernetes Job orchestrated by
   Keptn.
 logoURL: https://raw.githubusercontent.com/cncf/artwork/master/projects/keptn/stacked/color/keptn-stacked-color.svg
-digest: '2022-01-25T08:27:50Z'
+digest: '2022-02-21T08:27:50Z'
 license: Apache-2.0
 homeURL: https://keptn.sh/docs/integrations/
 keywords:
@@ -19,7 +19,8 @@ links:
 install: 'The *job-executor-service* can be installed as a part of [Keptns uniform](https://keptn.sh)
   using `helm`:
 
-  ```bash helm install -n keptn job-executor-service https://github.com/keptn-contrib/job-executor-service/releases/download/<VERSION>/job-executor-service-<VERSION>.tgz
+  ```bash 
+  helm install -n keptn job-executor-service https://github.com/keptn-contrib/job-executor-service/releases/download/<VERSION>/job-executor-service-<VERSION>.tgz
   ```
 
   Please replace `<VERSION>` with the actual version you want to install from the
@@ -29,6 +30,6 @@ install: 'The *job-executor-service* can be installed as a part of [Keptns unifo
 recommendations:
 - url: https://artifacthub.io/packages/helm/keptn/keptn
 annotations:
-  keptn/kind: testing,deployment,notification,observability
-  keptn/org: contrib
-  keptn/version: 0.9.0-0.11.3
+  keptn/kind: "testing,deployment,notification,observability"
+  keptn/org: "contrib"
+  keptn/version: "0.10.0-0.11.3"

--- a/prometheus/0.7.2/artifacthub-pkg.yml
+++ b/prometheus/0.7.2/artifacthub-pkg.yml
@@ -4,7 +4,7 @@ displayName: Prometheus Service
 createdAt: '2021-12-17T14:12:49Z'
 description: Keptn service for utilizing Prometheus monitoring and alerting in Keptn
 logoURL: https://raw.githubusercontent.com/cncf/artwork/master/projects/prometheus/stacked/color/prometheus-stacked-color.svg
-digest: '2021-12-17T14:12:49Z'
+digest: '2022-02-21T08:12:49Z'
 license: Apache-2.0
 homeURL: https://keptn.sh/docs/integrations/
 keywords:
@@ -41,6 +41,6 @@ install: '## Execute the following steps to install prometheus-service:
 recommendations:
 - url: https://artifacthub.io/packages/helm/keptn/keptn
 annotations:
-  keptn/kind: observability
-  keptn/org: contrib
-  keptn/version: 0.9.0-0.11.3
+  keptn/kind: "observability"
+  keptn/org: "contrib"
+  keptn/version: "0.10.0-0.11.3"


### PR DESCRIPTION
* Changed digest of latest version of prometheus and job-executor in order to get processed
* Updated version compatibility of those two releases
* Fixed a formatting error in job-executor-service install instructions

