### PR TITLE
fix: 'Send PR comment' step not working for people creating the PR that don't have permission to the repository

### DIFF
--- a/.github/workflows/ah_lint_pr.yml
+++ b/.github/workflows/ah_lint_pr.yml
@@ -2,7 +2,7 @@ name: ArtifactHub Linter PR
 
 on:
   # Triggers the workflow on pull request events but only for the main branch
-  pull_request:
+  pull_request_target:
     branches: [ main ]
 
 jobs:


### PR DESCRIPTION
Fixes #89. This should not be a security concern as far as I'm aware since we are only running the AH linter and create a PR comment.