### PR TITLE
fix: Changed all still existing relative paths to absolute path to make them work with Artifacthub

### DIFF
--- a/dynatrace/0.16.0/artifacthub-pkg.yml
+++ b/dynatrace/0.16.0/artifacthub-pkg.yml
@@ -6,7 +6,7 @@ displayName: Dynatrace Service
 createdAt: 2021-08-09T00:00:00Z
 description: Keptn service that forwards Keptn events - occurring during a delivery workflow - to Dynatrace.
 logoURL: https://avatars.githubusercontent.com/u/6412311
-digest: 2021-10-12T00:00:00Z
+digest: 2022-03-11T00:00:00Z
 license: Apache-2.0
 homeURL: https://keptn.sh/docs/integrations/
 keywords:
@@ -99,7 +99,7 @@ install: |
 
   * When an event is sent out by Keptn, you see an event in Dynatrace for the correlating service:
 
-    ![Dynatrace events](images/events.png?raw=true "Dynatrace Events")
+    ![Dynatrace events](https://raw.githubusercontent.com/keptn-contrib/dynatrace-service/release-0.16.0/documentation/images/events.png)
 
   ### 4. (Optional) Set up Dynatrace monitoring for existing Keptn projects
 

--- a/dynatrace/0.17.0/artifacthub-pkg.yml
+++ b/dynatrace/0.17.0/artifacthub-pkg.yml
@@ -6,7 +6,7 @@ displayName: Dynatrace Service
 createdAt: 2021-09-27T00:00:00Z
 description: Keptn service that forwards Keptn events - occurring during a delivery workflow - to Dynatrace.
 logoURL: https://avatars.githubusercontent.com/u/6412311
-digest: 2022-01-18T00:00:00Z
+digest: 2022-03-11T00:00:00Z
 license: Apache-2.0
 homeURL: https://keptn.sh/docs/integrations/
 keywords:
@@ -101,7 +101,7 @@ install: |
 
   * When an event is sent out by Keptn, you see an event in Dynatrace for the correlating service:
 
-    ![Dynatrace events](images/events.png?raw=true "Dynatrace Events")
+    ![Dynatrace events](https://raw.githubusercontent.com/keptn-contrib/dynatrace-service/release-0.17.0/documentation/images/events.png)
 
   ### 4. (Optional) Set up Dynatrace monitoring for existing Keptn projects
 

--- a/zapier/1.0.0/README.md
+++ b/zapier/1.0.0/README.md
@@ -34,4 +34,4 @@ Create 2 zaps.
 - The first Zap lets you email Zapier with a formatted email. It then parses the email for Keptn details and triggers a sequence (using the Keptn API webhook).
 - The second Zap relies on the Keptn webhook service listening for whatever event you like, the zap takes that payload and emails it to you.
   
-![keptn zapier integration](assets/2zaps.png)
+![keptn zapier integration](https://raw.githubusercontent.com/keptn-contrib/artifacthub/main/zapier/1.0.0/assets/2zaps.png)

--- a/zapier/1.0.0/artifacthub-pkg.yml
+++ b/zapier/1.0.0/artifacthub-pkg.yml
@@ -5,7 +5,8 @@ name: Zapier Integration
 displayName: Zapier Integration
 createdAt: 2022-02-04T00:00:00Z
 description: Keptn integration with Zapier.com
-digest: 2022-03-09T00:00:00Z
+logoURL: https://www.amocrm.com/static/images/pages/integrations/logo/zapier.png
+digest: 2022-03-11T00:00:00Z
 license: Apache-2.0
 homeURL: https://keptn.sh/docs/integrations/
 keywords:
@@ -54,7 +55,7 @@ install: |
   - The first Zap lets you email Zapier with a formatted email. It then parses the email for Keptn details and triggers a sequence (using the Keptn API webhook).
   - The second Zap relies on the Keptn webhook service listening for whatever event you like, the zap takes that payload and emails it to you.
   
-  ![keptn zapier integration](assets/2zaps.png)
+  ![keptn zapier integration](https://raw.githubusercontent.com/keptn-contrib/artifacthub/main/zapier/1.0.0/assets/2zaps.png)
 recommendations:
   - url: https://artifacthub.io/packages/helm/keptn/keptn
 annotations:


### PR DESCRIPTION
Changed existing relative image paths to absolute paths since currently Artifacthub doesn't support relative paths. he reason is that when processing packages AH only reads the metadata files. They don't store or serve any other files.

ArtifactHub discussion on the topic: https://github.com/artifacthub/hub/issues/629