### PR TITLE
fix: Fixed ah pr linter pr target bug

### DIFF
--- a/.github/workflows/ah_lint_pr.yml
+++ b/.github/workflows/ah_lint_pr.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          ref: "refs/pull/${{ github.event.number }}/merge"
       
       - id: files
         uses: Ana06/get-changed-files@v2.1.0


### PR DESCRIPTION
Currently the [ah_lint_pr action](https://github.com/keptn-contrib/artifacthub/blob/main/.github/workflows/ah_lint_pr.yml) fails at the [`copy_files` step](https://github.com/keptn-contrib/artifacthub/blob/main/.github/workflows/ah_lint_pr.yml) with the following error message:

```
Run # Copy artifacthub-pkg.yml and parent folder into new folder
  # Copy artifacthub-pkg.yml and parent folder into new folder
  mkdir changed_services && cp -pv --parents folder/1.0.0/artifacthub-pkg.yml changed_services
  shell: /usr/bin/bash -e {0}
cp: failed to get attributes of 'folder': No such file or directory
Error: Process completed with exit code 1.
```

After doing some debugging it turns out that this only happens for `pull_request_target` and works fine with `pull_request`.

![image](https://user-images.githubusercontent.com/36239763/159676349-198f78e9-42af-490e-b2a7-2501a44df260.png)

When using `pull_request_target` the new service isn't fetched by `actions/checkout@v2` even though the `get-changed-files` action seems to fetch the data without a problem.

![image](https://user-images.githubusercontent.com/36239763/159684086-4dcefad2-1d7e-4fa0-8934-96b49e28ac0a.png)

This seems to be a problem with the `actions/checkout@v2` when working with `pull_request_target`. To fix this a `ref` needed to be added as described in https://github.com/actions/checkout/issues/518#issuecomment-890401887.

![image](https://user-images.githubusercontent.com/36239763/159684412-f2d84aca-74f4-41aa-bb66-da6ecec5f426.png)
