### PR TITLE
Add example for `generate_config.py`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Images can be added to the README or `artifacthub-pkg.yml` file using [Markdown 
 
 ## Generate draft from a Github repository
 
-To quickly generate a draft of the `README.md` and `artifacthub-pkg.yml` for a new service, use the [`generate_config.py` file](generate_config.py).
+To quickly generate a draft of the `README.md` and `artifacthub-pkg.yml` for a new service, use the [`generate_config.py` file](generate_config.py). 
 
 ```
 usage: generate_config.py [-h] -r REPOSITORY [-v VERSION]
@@ -24,17 +24,19 @@ optional arguments:
   -v VERSION, --version VERSION
                         Version (default=latest)
 ```
-Example:
+
+Before the script can be executed the first time, the required dependencies have to be installed via pip (should be executed from the root of the repository):
+
 ```bash
-# cd artifacthub
-python3 generate_config.py -r keptn-sandbox/datadog-service -v 0.2.0
-```
-Use pip to install the dependencies like this:
-```bash
-# cd artifacthub
 pip install -r requirements.txt 
 ```
-The script was tested with python 3.8.10 (available by default on Ubuntu 20.04) and pip 3.8 
+
+Generate the config like this (should be executed from the root of the repository):
+```bash
+python3 generate_config.py -r keptn-sandbox/datadog-service -v 0.2.0
+```
+
+The script was tested with Python 3.
 
 
 ## Update existing version of a service

--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ optional arguments:
   -v VERSION, --version VERSION
                         Version (default=latest)
 ```
+Example:
+```bash
+# cd artifacthub
+python3 generate_config.py -r keptn-sandbox/datadog-service -v 0.2.0
+```
+Use pip to install the dependencies like this:
+```bash
+# cd artifacthub
+pip install -r requirements.txt 
+```
+The script was tested with python 3.8.10 (available by default on Ubuntu 20.04) and pip 3.8 
+
 
 ## Update existing version of a service
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Generate the config like this (should be executed from the root of the repositor
 python3 generate_config.py -r keptn-sandbox/datadog-service -v 0.2.0
 ```
 
-The script was tested with Python 3.
+The script was tested with Python 3.8.10.
 
 
 ## Update existing version of a service

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ python3 generate_config.py -r keptn-sandbox/datadog-service -v 0.2.0
 
 The script was tested with Python 3.8.10.
 
-
 ## Update existing version of a service
 
 For updates of an existing version to take effect on Artifacthub, the `digest` parameter needs to be updated or added to the `artifacthub-pkg.yml` file of that version. A change of the digest parameter signals the Artifacthub backend to reprocess that version. To ensure the new `digest` value is unique, we use the current date of the change with the same format as the `createdAt` argument (RFC3339).


### PR DESCRIPTION
## Why
- I think an example of how to use the script would help folks who don't use python on a regular basis