### PR TITLE
docs(datadog-service): fix newline spacing

### DIFF
--- a/datadog-service/0.15.0/artifacthub-pkg.yml
+++ b/datadog-service/0.15.0/artifacthub-pkg.yml
@@ -19,9 +19,11 @@ annotations:
 install: '## Execute the following steps to install datadog-service:
 
   ```bash 
-  export DD_API_KEY="<your-datadog-api-key>" DD_APP_KEY="<your-datadog-app-key>" DD_SITE="datadoghq.com"
-  helm install -n keptn datadog-service https://github.com/keptn-sandbox/datadog-service/releases/download/0.15.0/datadog-service-0.15.0.tar.gz --set datadogservice.ddApikey=${DD_API_KEY} --set datadogservice.ddAppKey=${DD_APP_KEY} --set datadogservice.ddSite=${DD_SITE}
-  ```
+  export DD_API_KEY="<your-datadog-api-key>" DD_APP_KEY="<your-datadog-app-key>" DD_SITE="datadoghq.com"  
+
+  helm install -n keptn datadog-service https://github.com/keptn-sandbox/datadog-service/releases/download/0.15.0/datadog-service-0.15.0.tar.gz --set datadogservice.ddApikey=${DD_API_KEY} --set datadogservice.ddAppKey=${DD_APP_KEY} --set datadogservice.ddSite=${DD_SITE}  
+  ```  
+  
   Check [the official docs](https://docs.datadoghq.com/account_management/api-app-keys/) for how to create Datadog API key and Application key
 
 

--- a/datadog-service/0.15.0/artifacthub-pkg.yml
+++ b/datadog-service/0.15.0/artifacthub-pkg.yml
@@ -9,6 +9,8 @@ homeURL: https://keptn.sh/docs/integrations/
 keywords:
 - keptn
 - sandbox
+- observability
+- monitoring
 links:
 - name: Source
   url: https://github.com/keptn-sandbox/datadog-service/tree/release-0.15.0
@@ -16,17 +18,14 @@ annotations:
   keptn/org: sandbox
   keptn/kind: observability
   keptn/version: 0.15.x
-install: '## Execute the following steps to install datadog-service:
-
-  ```bash 
-  export DD_API_KEY="<your-datadog-api-key>" DD_APP_KEY="<your-datadog-app-key>" DD_SITE="datadoghq.com"  
-
-  helm install -n keptn datadog-service https://github.com/keptn-sandbox/datadog-service/releases/download/0.15.0/datadog-service-0.15.0.tar.gz --set datadogservice.ddApikey=${DD_API_KEY} --set datadogservice.ddAppKey=${DD_APP_KEY} --set datadogservice.ddSite=${DD_SITE}  
-  ```  
-  
-  Check [the official docs](https://docs.datadoghq.com/account_management/api-app-keys/) for how to create Datadog API key and Application key
-
-
-  ### More Information
-
-  More information can be found in our [GitHub repository](https://github.com/keptn-sandbox/datadog-service). '
+install: "## Execute the following steps to install datadog-service:\n\n\
+  \ ```\n\ 
+  \ export DD_API_KEY='<your-datadog-api-key>' DD_APP_KEY='<your-datadog-app-key>' DD_SITE='datadoghq.com' \n\n\ 
+  \ helm install -n keptn datadog-service https://github.com/keptn-sandbox/datadog-service/releases/download/0.15.0/ \  
+  \ datadog-service-0.15.0.tar.gz --set datadogservice.ddApikey=${DD_API_KEY} --set datadogservice.ddAppKey=${DD_APP_KEY} --set \
+  \ datadogservice.ddSite=${DD_SITE} \n\
+  \ ``` \n\n\  
+  \ Check [the official docs](https://docs.datadoghq.com/account_management/api-app-keys/) for \n\ 
+  \ how to create Datadog API key and Application key \n\n\n\
+  \ ### More Information \n\n\
+  \ More information can be found in our [GitHub repository](https://github.com/keptn-sandbox/datadog-service)."


### PR DESCRIPTION
Signed-off-by: Suraj Banakar <surajrbanakar@gmail.com>
(cherry picked from commit 0821fbeaeacc2b1c9b807b2275ffaf0be67b4276)

## Why?
Many lines in installation instructions show up as one line. 
![image](https://user-images.githubusercontent.com/34534103/179671237-77f7aa6c-b4d1-48b1-80a1-3a5108bba4cc.png)
https://artifacthub.io/packages/keptn/keptn-integrations/datadog-service

This PR attempts to fix that. This PR only changes the spacing. **No change in content was made.**