### PR TITLE
fix:Added missing keywords in artifacthub-pkg.yml

### DIFF
--- a/datadog-service/0.15.0/artifacthub-pkg.yml
+++ b/datadog-service/0.15.0/artifacthub-pkg.yml
@@ -13,6 +13,8 @@ keywords:
 - observability
 - monitoring
 - sli-provider
+- datadog
+- datadog-service
 links:
 - name: Source
   url: https://github.com/keptn-sandbox/datadog-service/tree/release-0.15.0

--- a/datadog-service/0.16.0/artifacthub-pkg.yml
+++ b/datadog-service/0.16.0/artifacthub-pkg.yml
@@ -10,6 +10,11 @@ homeURL: https://keptn.sh/docs/integrations/
 keywords:
 - keptn
 - sandbox
+- obsevability
+- monitoring
+- sli-provider
+- datadog
+- datadog-service
 links:
 - name: Source
   url: https://github.com/keptn-sandbox/datadog-service/tree/release-0.16.0

--- a/datadog-service/0.17.0/artifacthub-pkg.yml
+++ b/datadog-service/0.17.0/artifacthub-pkg.yml
@@ -10,6 +10,11 @@ homeURL: https://keptn.sh/docs/integrations/
 keywords:
 - keptn
 - sandbox
+- obsevability
+- monitoring
+- sli-provider
+- datadog
+- datadog-service
 links:
 - name: Source
   url: https://github.com/keptn-sandbox/datadog-service/tree/release-0.17.0

--- a/datadog-service/0.18.1/artifacthub-pkg.yml
+++ b/datadog-service/0.18.1/artifacthub-pkg.yml
@@ -10,6 +10,11 @@ homeURL: https://keptn.sh/docs/integrations/
 keywords:
 - keptn
 - sandbox
+- obsevability
+- monitoring
+- sli-provider
+- datadog
+- datadog-service
 links:
 - name: Source
   url: https://github.com/keptn-sandbox/datadog-service/tree/release-0.18.1

--- a/datadog-service/0.19.0/artifacthub-pkg.yml
+++ b/datadog-service/0.19.0/artifacthub-pkg.yml
@@ -10,6 +10,11 @@ homeURL: https://keptn.sh/docs/integrations/
 keywords:
 - keptn
 - sandbox
+- obsevability
+- monitoring
+- sli-provider
+- datadog
+- datadog-service
 links:
 - name: Source
   url: https://github.com/keptn-sandbox/datadog-service/tree/release-0.19.0


### PR DESCRIPTION
datadog-service does not shows up in keptn integration page under observability and SLI section.

Signed-off-by: Tarang Verma <tarangverma004@gmail.com>