### PR TITLE
deprecate AWS Lambda Integration

### DIFF
--- a/aws_lambda/1.0.0/README.md
+++ b/aws_lambda/1.0.0/README.md
@@ -1,3 +1,7 @@
+> This integration is for Keptn v1. It is no longer supported.
+>
+> Users are advised to use Keptn instead: https://keptn.sh
+
 # Use AWS Lambda with Keptn
 
   There are two ways AWS Lambda can be used with keptn/kind:

--- a/aws_lambda/1.0.0/artifacthub-pkg.yml
+++ b/aws_lambda/1.0.0/artifacthub-pkg.yml
@@ -2,11 +2,12 @@
 # https://github.com/artifacthub/hub/blob/master/docs/metadata/artifacthub-pkg.yml
 version: 1.0.0
 name: aws-lambda
+deprecated: true
 displayName: AWS Lambda Integration
 createdAt: 2022-05-10T00:00:00Z
-description: Use AWS Lambda with Keptn
+description: "[DEPRECATED] Use AWS Lambda with Keptn"
 logoURL: https://raw.githubusercontent.com/keptn-contrib/artifacthub/main/aws_lambda/1.0.0/assets/Lambda.svg
-digest: 2022-05-13T00:00:00Z
+digest: 2023-09-05T00:00:00Z
 license: Apache-2.0
 homeURL: https://keptn.sh/docs/integrations/
 keywords:


### PR DESCRIPTION
This PR:

- Deprecates the AWS Lambda Keptn v1 integration