### PR TITLE
Deprecate app runner

### DIFF
--- a/awsapprunner/1.0.0/README.md
+++ b/awsapprunner/1.0.0/README.md
@@ -1,3 +1,7 @@
+> This integration is for Keptn v1. It is no longer supported.
+>
+> Users are advised to use Keptn instead: https://keptn.sh
+
 # AWS App Runner Integration
 
 Keptn can integrate with AWS App Runner in 3 ways:

--- a/awsapprunner/1.0.0/artifacthub-pkg.yml
+++ b/awsapprunner/1.0.0/artifacthub-pkg.yml
@@ -2,11 +2,12 @@
 # https://github.com/artifacthub/hub/blob/master/docs/metadata/artifacthub-pkg.yml
 version: 1.0.0
 name: aws-app-runner
+deprecated: true
 displayName: AWS App Runner Keptn Integration
 createdAt: 2021-05-13T00:00:00Z
 description: Use AWS App Runner with Keptn
 logoURL: https://raw.githubusercontent.com/keptn-contrib/artifacthub/main/awsapprunner/1.0.0/assets/Arch_AWS-App-Runner_64.svg
-digest: 2021-05-15T00:00:00Z
+digest: 2023-09-05T00:00:00Z
 license: Apache-2.0
 homeURL: https://keptn.sh/docs/integrations/
 keywords:


### PR DESCRIPTION
This PR:
- Deprecates the Keptn v1 integration for AWS app runner